### PR TITLE
chore: Use GHCR for images instead of Dockerhub.

### DIFF
--- a/.github/workflows/d2iq-release-tag-version.yml
+++ b/.github/workflows/d2iq-release-tag-version.yml
@@ -18,7 +18,7 @@ jobs:
   docker-rootless:
     runs-on: 
       - self-hosted
-      - small
+      - large
     permissions:
         contents: read
         packages: write

--- a/.github/workflows/d2iq-release-tag-version.yml
+++ b/.github/workflows/d2iq-release-tag-version.yml
@@ -12,13 +12,16 @@ on:
         description: 'Release Image Name'
         type: string
         required: true
-        default: 'docker.io/mesosphere/gitea:latest'
+        default: 'ghcr.io/mesosphere/gitea:latest'
 
 jobs:
   docker-rootless:
     runs-on: 
       - self-hosted
       - small
+    permissions:
+        contents: read
+        packages: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -29,8 +32,9 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_READ_WRITE_USERNAME }}
-          password: ${{ secrets.DOCKER_READ_WRITE_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: build rootless docker image
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
- Use GHCR for images instead of Dockerhub. A successful run can be found [here](https://github.com/mesosphere/gitea/actions/runs/7412568979/job/20169644930).
- Update self-hosted runners to use `large` instead of `small`, the previous test run took over an hour.
